### PR TITLE
feat: navigation screen, demo project, and TUI hang fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,39 @@
 
 A terminal-based lakehouse observability platform for exploring and managing data sources from your command line.
 
+![Project](docs/project-screen.svg)
+
+---
+
+## Quickstart
+
+The fastest way to see Lakefront in action is the built-in demo:
+
+```bash
+uv run lakefront init
+uv run lakefront demo
+```
+
+This seeds a sample project with two CSV datasets and opens it straight in the TUI.
+
+To set up your own project instead:
+
+```bash
+# 1. Initialise ~/.lakefront
+uv run lakefront init
+
+# 2. Create a project
+uv run lakefront projects create my-project -d "My first project"
+
+# 3. Attach a data source (local Parquet or CSV)
+uv run lakefront projects source add -p my-project -n orders -k local --path /data/orders.parquet
+
+# 4. Open the TUI
+uv run lakefront ui --project my-project
+```
+
+Running `lakefront ui` without `--project` opens a navigation screen listing all your projects.
+
 ---
 
 ## About
@@ -101,8 +134,6 @@ uv run lakefront projects source remove -p my-project -n raw
 
 The interactive TUI provides a rich, multi-pane interface for exploring and analyzing data without leaving the terminal.
 
-![Project](docs/project-screen.svg)
-
 ### Project Screen
 
 The main project workspace with a three-pane layout:
@@ -112,6 +143,7 @@ The main project workspace with a three-pane layout:
 - Browse all attached sources with expandable tree view
 - View column names and data types inline
 - Quickly navigate between sources
+- **P**: Load statistical profile for the selected source in the right pane
 
 **Center Pane — SQL Editor & Results:**
 
@@ -126,8 +158,9 @@ The main project workspace with a three-pane layout:
 
 **Right Pane — Profiler:**
 
-- Live query execution statistics
-- Row counts, memory usage, and timing information
+- Statistical summary for the selected source
+- Row counts, column types, null rates, and value distributions
+- Loaded on demand with **P** from the source pane
 
 ### Explore Screen
 

--- a/src/lakefront/cli/__init__.py
+++ b/src/lakefront/cli/__init__.py
@@ -52,14 +52,36 @@ def run_app(project: str):
     LakefrontApp(ctx).run()
 
 
+def run_nav():
+    from lakefront.core.config import LAKEFRONT_HOME
+    from lakefront.log import configure_for_tui
+    from lakefront.tui.app import LakefrontApp
+
+    log_file = LAKEFRONT_HOME / "lakefront.log"
+    log_file.parent.mkdir(parents=True, exist_ok=True)
+    log_file.touch(exist_ok=True)
+    configure_for_tui(log_file)
+
+    LakefrontApp().run()
+
+
 @app.command()
 def demo():
-    console.print("[bold green]Starting demo...[/]")
+    """Launch the built-in demo project (creates it on first run)."""
+    from lakefront.core.demo import ensure_demo_project
+
+    console.print("[bold green]Setting up demo project...[/]")
+    ensure_demo_project()
     run_app("demo")
 
 
 @app.command()
 def ui(
-    project: str = typer.Option(..., "--project", "-p", help="Project to open"),
+    project: str = typer.Option(
+        None, "--project", "-p", help="Project to open (shows navigation screen if omitted)"
+    ),
 ):
-    run_app(project)
+    if project:
+        run_app(project)
+    else:
+        run_nav()

--- a/src/lakefront/core/__init__.py
+++ b/src/lakefront/core/__init__.py
@@ -4,6 +4,7 @@ from .config import (
     initialize,
     load_settings,
 )
+from .demo import ensure_demo_project
 from .exceptions import (
     LlmError,
     ProjectExistsError,
@@ -34,6 +35,7 @@ __all__ = [
     "ProfileConfigurationService",
     "ProjectConfigurationService",
     "ProjectContext",
+    "ensure_demo_project",
     "get_project",
     "load_settings",
     "list_projects",

--- a/src/lakefront/core/demo.py
+++ b/src/lakefront/core/demo.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import csv
+import random
+from datetime import datetime, timedelta
+from pathlib import Path
+
+
+def ensure_demo_project() -> None:
+    """Create the built-in demo project with sample data if it doesn't already exist."""
+    from lakefront import models
+    from lakefront.core.config import PROJECTS_DIR, ProjectConfigurationService
+
+    if "demo" in ProjectConfigurationService.list_projects():
+        return
+
+    ProjectConfigurationService.create("demo", description="Built-in sample datasets")
+
+    data_dir = PROJECTS_DIR / "demo" / "data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+
+    _write_orders(data_dir / "orders.csv")
+    _write_customers(data_dir / "customers.csv")
+
+    for name, path, desc in [
+        ("orders", str(data_dir / "orders.csv"), "Sample orders (500 rows)"),
+        ("customers", str(data_dir / "customers.csv"), "Sample customers (200 rows)"),
+    ]:
+        ProjectConfigurationService.add_source(
+            "demo", models.DataSource(name=name, path=path, description=desc)
+        )
+
+
+def _write_orders(path: Path) -> None:
+    rng = random.Random(42)
+    statuses = ["completed", "pending", "cancelled", "refunded"]
+    base = datetime(2024, 1, 1)
+    with path.open("w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(
+            ["order_id", "customer_id", "status", "created_at", "amount_usd", "discount_pct"]
+        )
+        for i in range(500):
+            writer.writerow([
+                10_000_001 + i,
+                rng.randint(1, 200),
+                rng.choice(statuses),
+                (base + timedelta(seconds=rng.randint(0, 86400 * 365))).isoformat(),
+                round(rng.uniform(5, 2000), 2) if rng.random() > 0.04 else "",
+                round(rng.uniform(0, 0.5), 3) if rng.random() > 0.45 else "",
+            ])
+
+
+def _write_customers(path: Path) -> None:
+    rng = random.Random(42)
+    countries = ["PL", "DE", "US", "FR", "GB"]
+    base = datetime(2020, 1, 1)
+    with path.open("w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["customer_id", "country", "signup_date", "ltv_usd", "is_active"])
+        for i in range(1, 201):
+            writer.writerow([
+                i,
+                rng.choice(countries),
+                (base + timedelta(days=rng.randint(0, 1500))).date().isoformat(),
+                round(rng.uniform(0, 10000), 2),
+                rng.random() > 0.2,
+            ])

--- a/src/lakefront/core/main.py
+++ b/src/lakefront/core/main.py
@@ -17,7 +17,11 @@ class ProjectContext(QueryEngineMixin, ContextBase):
     def __post_init__(self):
         self.settings = load_settings(profile=self.profile)
         self.sources = []
-        self.configure_s3()
+        # source_attach/source_detach both call reinitialize(), which reconstructs
+        # ProjectContext from scratch, so _sources already reflects the updated list
+        # and this guard stays correct after sources are added or removed at runtime.
+        if any(src.path.startswith("s3://") for src in self._sources):
+            self.configure_s3()
         for src in self._sources:
             logger.debug(f'Loading source "{src.name}" from path: {src.path}')
             source = Source(self, src)

--- a/src/lakefront/tui/app.py
+++ b/src/lakefront/tui/app.py
@@ -15,19 +15,27 @@ class LakefrontApp(App):
         Binding("shift+tab", "focus_previous", show=False),
     ]
 
-    def __init__(self, ctx: ProjectContext, **kwargs) -> None:
+    def __init__(self, ctx: ProjectContext | None = None, **kwargs) -> None:
         super().__init__(**kwargs)
         self.ctx = ctx
         self.sub_title = f"Lakehouse Observability Platform - v{get_version()}"
-        _theme = ctx.settings.core.theme
-        if _theme not in self.available_themes.keys():
-            self.theme = DEFAULT_THEME
-            self.notify(
-                f"Theme '{_theme} not found. Falling back to default theme '{DEFAULT_THEME}'.",
-                severity="warning",
-            )
+        if ctx is not None:
+            _theme = ctx.settings.core.theme
+            if _theme not in self.available_themes.keys():
+                self.theme = DEFAULT_THEME
+                self.notify(
+                    f"Theme '{_theme} not found. Falling back to default theme '{DEFAULT_THEME}'.",
+                    severity="warning",
+                )
+            else:
+                self.theme = _theme
         else:
-            self.theme = _theme
+            self.theme = DEFAULT_THEME
 
     def on_mount(self) -> None:
-        self.push_screen(ProjectScreen(self.ctx))
+        if self.ctx is not None:
+            self.push_screen(ProjectScreen(self.ctx))
+        else:
+            from lakefront.tui.screens.navigation import NavigationScreen
+
+            self.push_screen(NavigationScreen())

--- a/src/lakefront/tui/app.tcss
+++ b/src/lakefront/tui/app.tcss
@@ -234,3 +234,43 @@ ExploreScreen #body {
     padding: 0 1;
     height: 1;
 }
+
+
+/* ══════════════════════════════════════════════════════════════════
+   NavigationScreen
+   ══════════════════════════════════════════════════════════════════ */
+
+NavigationScreen {
+    layout: vertical;
+}
+
+#nav-body {
+    height: 1fr;
+    align: center middle;
+}
+
+#nav-container {
+    width: 80;
+    height: auto;
+    border: round $panel;
+    padding: 1 2;
+}
+
+#nav-title {
+    text-align: center;
+    color: $text-muted;
+    text-style: bold;
+    padding: 0 0 1 0;
+}
+
+#nav-empty {
+    text-align: center;
+    color: $text-muted;
+    padding: 2 1;
+}
+
+#projects-table {
+    height: auto;
+    max-height: 30;
+    border: none;
+}

--- a/src/lakefront/tui/screens/__init__.py
+++ b/src/lakefront/tui/screens/__init__.py
@@ -1,0 +1,5 @@
+from lakefront.tui.screens.explore import ExploreScreen
+from lakefront.tui.screens.navigation import NavigationScreen
+from lakefront.tui.screens.project import ProjectScreen
+
+__all__ = ["ExploreScreen", "NavigationScreen", "ProjectScreen"]

--- a/src/lakefront/tui/screens/explore.py
+++ b/src/lakefront/tui/screens/explore.py
@@ -101,7 +101,7 @@ class ExploreScreen(Screen):
         try:
             md = self.ctx.analyzer().ask_llm(question, self._profile)
         except LlmError as e:
-            self.notify(f"LLM request failed: {e}", severity="error")
+            self.app.call_from_thread(self.notify, f"LLM request failed: {e}", severity="error")
             md = f"**Error:** {e}"
         self.app.call_from_thread(self._set_insights, md)
 

--- a/src/lakefront/tui/screens/navigation.py
+++ b/src/lakefront/tui/screens/navigation.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Center, Vertical
+from textual.screen import Screen
+from textual.widgets import DataTable, Footer, Header, Static
+
+from lakefront import core
+
+
+class NavigationScreen(Screen):
+    """Main navigation screen — list all projects and select one to open."""
+
+    BINDINGS = [
+        Binding("q", "app.exit", "Quit", show=True),
+    ]
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._project_names = core.list_projects()
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+        with Center(id="nav-body"):
+            with Vertical(id="nav-container"):
+                yield Static("PROJECTS", id="nav-title")
+                if self._project_names:
+                    yield DataTable(id="projects-table", cursor_type="row")
+                else:
+                    yield Static(
+                        "No projects found.\n\n"
+                        "Run [bold]lakefront projects create <name>[/bold] to create one,\n"
+                        "or [bold]lakefront demo[/bold] to launch the built-in demo.",
+                        id="nav-empty",
+                        markup=True,
+                    )
+        yield Footer()
+
+    def on_mount(self) -> None:
+        if not self._project_names:
+            return
+        table = self.query_one("#projects-table", DataTable)
+        table.add_columns("Project", "Description", "Sources", "Updated")
+        for name in self._project_names:
+            try:
+                project = core.ProjectConfigurationService.get(name)
+                updated = project.updated_at.strftime("%Y-%m-%d")
+                description = project.description or "—"
+                sources = str(len(project.sources))
+            except Exception:
+                updated = "—"
+                description = "error loading project"
+                sources = "—"
+            table.add_row(name, description, sources, updated, key=name)
+        table.focus()
+
+    def on_data_table_row_selected(self, event: DataTable.RowSelected) -> None:
+        self._open_project(str(event.row_key.value))
+
+    def _open_project(self, name: str) -> None:
+        from lakefront.tui.screens.project import ProjectScreen
+
+        try:
+            ctx = core.get_project(name)
+        except core.ProjectNotFoundError:
+            self.notify(f"Project '{name}' not found.", severity="error")
+            return
+        try:
+            self.app.push_screen(ProjectScreen(ctx))
+        except Exception as e:
+            self.notify(f"Error opening project: {e}", severity="error")

--- a/src/lakefront/tui/screens/navigation.py
+++ b/src/lakefront/tui/screens/navigation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from textual import work
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Center, Vertical
@@ -16,33 +17,25 @@ class NavigationScreen(Screen):
         Binding("q", "app.exit", "Quit", show=True),
     ]
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-        self._project_names = core.list_projects()
-
     def compose(self) -> ComposeResult:
         yield Header()
         with Center(id="nav-body"):
             with Vertical(id="nav-container"):
                 yield Static("PROJECTS", id="nav-title")
-                if self._project_names:
-                    yield DataTable(id="projects-table", cursor_type="row")
-                else:
-                    yield Static(
-                        "No projects found.\n\n"
-                        "Run [bold]lakefront projects create <name>[/bold] to create one,\n"
-                        "or [bold]lakefront demo[/bold] to launch the built-in demo.",
-                        id="nav-empty",
-                        markup=True,
-                    )
+                yield DataTable(id="projects-table", cursor_type="row")
         yield Footer()
 
     def on_mount(self) -> None:
-        if not self._project_names:
+        self._load_projects()
+
+    @work(thread=True)
+    def _load_projects(self) -> None:
+        names = core.list_projects()
+        if not names:
+            self.app.call_from_thread(self._show_empty)
             return
-        table = self.query_one("#projects-table", DataTable)
-        table.add_columns("Project", "Description", "Sources", "Updated")
-        for name in self._project_names:
+        rows = []
+        for name in names:
             try:
                 project = core.ProjectConfigurationService.get(name)
                 updated = project.updated_at.strftime("%Y-%m-%d")
@@ -52,21 +45,46 @@ class NavigationScreen(Screen):
                 updated = "—"
                 description = "error loading project"
                 sources = "—"
-            table.add_row(name, description, sources, updated, key=name)
+            rows.append((name, description, sources, updated))
+        self.app.call_from_thread(self._populate_table, rows)
+
+    def _show_empty(self) -> None:
+        table = self.query_one("#projects-table", DataTable)
+        table.remove()
+        self.query_one("#nav-container", Vertical).mount(
+            Static(
+                "No projects found.\n\n"
+                "Run [bold]lakefront projects create <name>[/bold] to create one,\n"
+                "or [bold]lakefront demo[/bold] to launch the built-in demo.",
+                id="nav-empty",
+                markup=True,
+            )
+        )
+
+    def _populate_table(self, rows: list[tuple]) -> None:
+        table = self.query_one("#projects-table", DataTable)
+        table.add_columns("Project", "Description", "Sources", "Updated")
+        for row in rows:
+            table.add_row(*row, key=row[0])
         table.focus()
 
     def on_data_table_row_selected(self, event: DataTable.RowSelected) -> None:
         self._open_project(str(event.row_key.value))
 
+    @work(thread=True)
     def _open_project(self, name: str) -> None:
         from lakefront.tui.screens.project import ProjectScreen
 
         try:
             ctx = core.get_project(name)
         except core.ProjectNotFoundError:
-            self.notify(f"Project '{name}' not found.", severity="error")
+            self.app.call_from_thread(
+                self.notify, f"Project '{name}' not found.", severity="error"
+            )
             return
         try:
-            self.app.push_screen(ProjectScreen(ctx))
+            self.app.call_from_thread(self.app.push_screen, ProjectScreen(ctx))
         except Exception as e:
-            self.notify(f"Error opening project: {e}", severity="error")
+            self.app.call_from_thread(
+                self.notify, f"Error opening project: {e}", severity="error"
+            )

--- a/src/lakefront/tui/screens/project.py
+++ b/src/lakefront/tui/screens/project.py
@@ -41,3 +41,6 @@ class ProjectScreen(Screen):
             results_pane.run_query(message.sql, message.new_tab)
         except Exception as e:
             self.notify(f"Could not run query: {e}", severity="error")
+
+    def on_source_pane_profile_requested(self, message: SourcePane.ProfileRequested) -> None:
+        self.query_one("#profiler-pane", ProfilerPane)._load_profile(message.source_name)

--- a/src/lakefront/tui/widgets/profiler_pane.py
+++ b/src/lakefront/tui/widgets/profiler_pane.py
@@ -8,8 +8,6 @@ from textual.widgets import Static
 
 from lakefront.core import ProjectContext
 
-from .source_pane import SourcePane
-
 
 class ProfilerPane(Widget):
     """Right pane: summary statistics for the active source or result."""
@@ -20,28 +18,35 @@ class ProfilerPane(Widget):
         super().__init__(**kwargs)
         self.ctx = ctx
         self.border_title = "Summary"
+        self._generation = 0
 
     def on_focus(self) -> None:
         self.query_one("#profiler-container", VerticalScroll).focus()
 
     def compose(self) -> ComposeResult:
         with VerticalScroll(id="profiler-container", can_focus=True):
-            yield Static("Loading…", id="profiler-content")
-
-    def on_mount(self) -> None:
-        source_pane = self.screen.query_one(SourcePane)
-        self.watch(source_pane, "active_source", self._load_profile)
-
-        if source_pane.active_source is not None:
-            self._load_profile(source_pane.active_source)
+            yield Static(
+                "Press [bold]p[/bold] on a source to load its profile.",
+                id="profiler-content",
+                markup=True,
+            )
 
     @work(thread=True)
     def _load_profile(self, source_name: str) -> None:
-        """Sample the source and build a statistical profile."""
+        # Each call claims a new generation. If the user triggers profiling quickly,
+        # multiple workers run concurrently. Only the worker whose generation still
+        # matches _generation when it finishes is the latest request — all earlier
+        # ones discard their results instead of updating the UI with stale data.
+        self._generation += 1
+        generation = self._generation
         try:
-            self._profile = self.ctx.analyzer().analyze_source(source_name)
-            self.app.call_from_thread(self._render_stats, self._profile)
+            profile = self.ctx.analyzer().analyze_source(source_name)
+            if generation != self._generation:
+                return
+            self.app.call_from_thread(self._render_stats, profile)
         except Exception as e:
+            if generation != self._generation:
+                return
             self.app.call_from_thread(
                 self.query_one("#profiler-content", Static).update,
                 f"[red]Error loading source data profile:[/red] {e}",

--- a/src/lakefront/tui/widgets/results_pane.py
+++ b/src/lakefront/tui/widgets/results_pane.py
@@ -123,7 +123,7 @@ class ResultsPane(Widget):
                 self._apply_result, sql, tab_id, df, replace, elapsed_ms
             )
         except Exception as e:
-            self.notify(f"Error: {e}", severity="error")
+            self.app.call_from_thread(self.notify, f"Error: {e}", severity="error")
             self.app.call_from_thread(
                 self._update_result_message, "Error executing query"
             )

--- a/src/lakefront/tui/widgets/source_pane.py
+++ b/src/lakefront/tui/widgets/source_pane.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import VerticalScroll
+from textual.message import Message
 from textual.reactive import reactive
 from textual.widget import Widget
 from textual.widgets import Static
@@ -94,6 +95,11 @@ class SourceItem(Widget):
 class SourcePane(Widget):
     """Left pane: lists attached data sources grouped by kind."""
 
+    class ProfileRequested(Message):
+        def __init__(self, source_name: str) -> None:
+            super().__init__()
+            self.source_name = source_name
+
     can_focus = True
     # Reactive: holds the name of the currently active source
     active_source: reactive[str | None] = reactive(None)
@@ -102,6 +108,7 @@ class SourcePane(Widget):
         Binding("a", "attach", "Attach source", show=True),
         Binding("d", "detach", "Detach source", show=True),
         Binding("e", "explore", "Explore", show=True),
+        Binding("p", "profile", "Profile", show=True),
         Binding("h", "focus_prev_source", "Prev source", show=True),
         Binding("l", "focus_next_source", "Next source", show=True),
         Binding("j", "forward_j", "Down", show=True),
@@ -232,3 +239,9 @@ class SourcePane(Widget):
         from lakefront.tui.screens.explore import ExploreScreen
 
         self.app.push_screen(ExploreScreen(self.ctx, self.active_source))
+
+    def action_profile(self) -> None:
+        if self.active_source is None:
+            self.notify("Select a source first", severity="warning")
+            return
+        self.post_message(self.ProfileRequested(self.active_source))

--- a/tests/tui/test_tui.py
+++ b/tests/tui/test_tui.py
@@ -4,6 +4,7 @@ from lakefront import core
 from lakefront.tui.app import LakefrontApp
 from lakefront.tui.modals.confirm import ConfirmModal
 from lakefront.tui.modals.source_attach import SourceAttachModal
+from lakefront.tui.screens.navigation import NavigationScreen
 from lakefront.tui.screens.project import ProjectScreen
 from lakefront.tui.widgets.source_pane import SourcePane
 
@@ -65,3 +66,19 @@ async def test_app_exit(ctx):
     async with LakefrontApp(ctx).run_test() as pilot:
         await pilot.pause()
         await pilot.press("q")
+
+
+@pytest.mark.asyncio
+async def test_navigation_screen_mounted_without_ctx():
+    async with LakefrontApp().run_test() as pilot:
+        await pilot.pause()
+        assert isinstance(pilot.app.screen, NavigationScreen)
+
+
+@pytest.mark.asyncio
+async def test_navigation_screen_lists_projects():
+    async with LakefrontApp().run_test() as pilot:
+        await pilot.pause()
+        screen = pilot.app.screen
+        assert isinstance(screen, NavigationScreen)
+        assert len(screen._project_names) == len(core.list_projects())

--- a/tests/tui/test_tui.py
+++ b/tests/tui/test_tui.py
@@ -79,6 +79,9 @@ async def test_navigation_screen_mounted_without_ctx():
 async def test_navigation_screen_lists_projects():
     async with LakefrontApp().run_test() as pilot:
         await pilot.pause()
+        await pilot.pause()  # allow worker to complete
         screen = pilot.app.screen
         assert isinstance(screen, NavigationScreen)
-        assert len(screen._project_names) == len(core.list_projects())
+        from textual.widgets import DataTable
+        table = screen.query_one("#projects-table", DataTable)
+        assert table.row_count == len(core.list_projects())


### PR DESCRIPTION
## Summary

- Adds a `NavigationScreen` shown when no project is passed to `lakefront ui`, listing all projects and allowing selection
- Adds a `demo` CLI command that seeds sample CSV data on first run and launches it
- Fixes several places where the TUI could hang or deadlock

## Hang fixes

- **Thread-unsafe `notify`** — `self.notify()` was called directly from `@work(thread=True)` workers in `ResultsPane` and `ExploreScreen`; replaced with `call_from_thread`
- **Blocking main-thread I/O in `NavigationScreen`** — `list_projects()`, project config loading, and `get_project()` (which constructs a `ProjectContext` including DuckDB setup) all ran on the event-loop thread; moved into `@work(thread=True)` workers
- **Unconditional `configure_s3()`** — called on every `ProjectContext` construction even for local-only projects, triggering `LOAD httpfs` / `INSTALL httpfs` (a network download); now skipped unless a source with an `s3://` path is present
- **Eager profiling stacking workers** — `ProfilerPane` watched `active_source` and spawned a new DuckDB+pandas worker on every source selection; replaced with an explicit `p` keybind that triggers profiling on demand

## Test plan

- [x] `lakefront ui` opens navigation screen, lists projects, selecting one opens `ProjectScreen`
- [x] `lakefront demo` seeds demo project on first run and opens it
- [x] `lakefront ui --project <name>` opens project directly
- [x] Pressing `p` in the source pane loads the profile in the profiler pane
- [x] Error notifications appear correctly when queries or LLM calls fail
- [x] All existing tests pass (`pytest tests/`)

Closes #24 

🤖 Generated with [Claude Code](https://claude.com/claude-code)