### PR TITLE
fix(tui): source pane navigation bugs

### DIFF
--- a/src/lakefront/tui/widgets/source_pane.py
+++ b/src/lakefront/tui/widgets/source_pane.py
@@ -47,7 +47,7 @@ class SourceItem(Widget):
                 self._fetch_columns()
             for col_name, col_type in self._columns:
                 yield FocusableStatic(
-                    f"  {col_name}  [{col_type}]", classes="column-row"
+                    f"  {col_name}: {col_type}", markup=False, classes="column-row"
                 )
 
     def _fetch_columns(self):

--- a/src/lakefront/tui/widgets/source_pane.py
+++ b/src/lakefront/tui/widgets/source_pane.py
@@ -143,13 +143,27 @@ class SourcePane(Widget):
         else:
             self.notify("No active source", timeout=1)
 
+    def _focused_source_item(self) -> "SourceItem | None":
+        """Return the SourceItem that owns the current focus, even when a child has focus."""
+        focused = self.app.focused
+        if isinstance(focused, SourceItem):
+            return focused
+        # When a source is expanded, focus moves to a FocusableStatic child inside
+        # the SourceItem rather than the SourceItem itself. Walk up the ancestor chain
+        # so h/l navigation still knows which source is currently active.
+        if focused is not None:
+            for ancestor in focused.ancestors:
+                if isinstance(ancestor, SourceItem):
+                    return ancestor
+        return None
+
     def action_focus_next_source(self) -> None:
         items: list[SourceItem] = list(self.query(SourceItem))
         if not items:
             return
-        focused = self.app.focused
+        current = self._focused_source_item()
         try:
-            idx = items.index(focused) if isinstance(focused, SourceItem) else -1
+            idx = items.index(current) if current is not None else -1
         except ValueError:
             idx = -1
         next_idx = (idx + 1) % len(items)
@@ -162,9 +176,9 @@ class SourcePane(Widget):
         items: list[SourceItem] = list(self.query(SourceItem))
         if not items:
             return
-        focused = self.app.focused
+        current = self._focused_source_item()
         try:
-            idx = items.index(focused) if isinstance(focused, SourceItem) else 0
+            idx = items.index(current) if current is not None else 0
         except ValueError:
             idx = 0
         prev_idx = (idx - 1) % len(items)

--- a/tests/tui/test_tui.py
+++ b/tests/tui/test_tui.py
@@ -6,7 +6,7 @@ from lakefront.tui.modals.confirm import ConfirmModal
 from lakefront.tui.modals.source_attach import SourceAttachModal
 from lakefront.tui.screens.navigation import NavigationScreen
 from lakefront.tui.screens.project import ProjectScreen
-from lakefront.tui.widgets.source_pane import SourcePane
+from lakefront.tui.widgets.source_pane import SourceItem, SourcePane
 
 
 @pytest.fixture(scope="module")
@@ -66,6 +66,21 @@ async def test_app_exit(ctx):
     async with LakefrontApp(ctx).run_test() as pilot:
         await pilot.pause()
         await pilot.press("q")
+
+
+@pytest.mark.asyncio
+async def test_source_item_shows_column_types(ctx):
+    async with LakefrontApp(ctx).run_test() as pilot:
+        await pilot.pause()
+        source_pane = pilot.app.screen.query_one(SourcePane)
+        first_item = source_pane.query(SourceItem).first()
+        first_item.focus()
+        await pilot.press("space")  # expand
+        await pilot.pause()
+        assert len(first_item._columns) > 0, "No columns fetched after expanding source"
+        for col_name, col_type in first_item._columns:
+            assert col_name != "", "Column name is empty"
+            assert col_type != "", f"Column type is empty for column: {col_name!r}"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes two bugs in the source pane reported in #27.

- **h/l keybinds broken when source is expanded** — when a source was expanded, focus moved to a `FocusableStatic` child rather than the `SourceItem` itself, causing `h`/`l` to lose track of the active source. Added `_focused_source_item()` to walk the ancestor chain and find the owning `SourceItem` regardless of which child has focus.
- **Column types not displayed** — DuckDB types containing brackets (e.g. `INTEGER[]`, `MAP(VARCHAR, INTEGER)`) were silently swallowed by Rich's markup parser. Fixed by setting `markup=False` on column row widgets.

## Test plan

- [x] Expand a source with `space`, then press `h`/`l` — should switch sources without needing to collapse first
- [x] Expand a source — column rows should show both name and type (e.g. `order_id: INTEGER`)
- [x] Array/complex types (e.g. `INTEGER[]`) render correctly
- [x] All existing tests pass (`pytest tests/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)