### PR TITLE
fix(core): validate source name and path in source_attach

### DIFF
--- a/src/lakefront/core/main.py
+++ b/src/lakefront/core/main.py
@@ -1,15 +1,18 @@
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 
-from lakefront import models
+from lakefront import models, util
 from lakefront.log import logger
 
 from .analyzer import Analyzer
 from .base import ContextBase, QueryResult, Source
 from .config import PROJECTS_DIR, ProjectConfigurationService, load_settings
-from .exceptions import SourceNotFoundError
+from .exceptions import LakefrontError, SourceExistsError, SourceNotFoundError
 from .query import QueryEngineMixin
+
+_VALID_IDENTIFIER = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
 @dataclass
@@ -87,8 +90,16 @@ class ProjectContext(QueryEngineMixin, ContextBase):
 
     def source_attach(self, name: str, path: str, kind: str) -> ProjectContext:
         """Attach a new source to the project and reinitialize the context."""
+        if not _VALID_IDENTIFIER.match(name):
+            raise LakefrontError(
+                f'Invalid source name "{name}". '
+                "Names must start with a letter or underscore and contain only "
+                "letters, digits, and underscores."
+            )
+        if not util.PathInfo(path, self.profile).exists():
+            raise LakefrontError(f'Path "{path}" does not exist or is inaccessible.')
         if any(s.name == name for s in self.sources):
-            raise ValueError(f'Source with name "{name}" already exists.')
+            raise SourceExistsError(f'Source with name "{name}" already exists.')
 
         new_source = models.DataSource(name=name, path=path)
         ProjectConfigurationService.add_source(self.name, new_source)

--- a/src/lakefront/tui/widgets/source_pane.py
+++ b/src/lakefront/tui/widgets/source_pane.py
@@ -9,6 +9,7 @@ from textual.widget import Widget
 from textual.widgets import Static
 
 from lakefront import core
+from lakefront.core.exceptions import LakefrontError
 from lakefront.tui.modals.confirm import ConfirmModal
 from lakefront.tui.modals.source_attach import SourceAttachModal
 
@@ -209,7 +210,11 @@ class SourcePane(Widget):
             self.notify("Cancelled", severity="warning")
         else:
             name, path = result["name"], result["path"]
-            self.ctx.source_attach(name=name, path=path, kind="local")
+            try:
+                self.ctx.source_attach(name=name, path=path, kind="local")
+            except LakefrontError as e:
+                self.notify(str(e), severity="error", timeout=8)
+                return
             self.ctx = self.ctx.reinitialize()  # ← reload context to include new source
             self._rebuild_sources()
             self.notify(

--- a/tests/core/test_main.py
+++ b/tests/core/test_main.py
@@ -1,6 +1,7 @@
 import pytest
 
 from lakefront import core, models
+from lakefront.core.exceptions import LakefrontError, SourceExistsError
 
 
 def test_context_is_created(ctx):
@@ -42,10 +43,23 @@ def test_context_source_not_found_ignored():
     assert len(ctx.sources) == 0
 
 
-def test_context_source_attach_invalid_ignored(ctx):
-    src = "nonexisting.csv"
-    ctx.source_attach("myfile", kind="local", path=src)
-    assert len(ctx.sources) == 3
+def test_context_source_attach_nonexistent_path_raises(ctx):
+    with pytest.raises(LakefrontError, match="does not exist"):
+        ctx.source_attach("myfile", kind="local", path="nonexisting.csv")
+
+
+def test_context_source_attach_invalid_name_raises(tmp_path, ctx):
+    src = tmp_path / "file.csv"
+    src.touch()
+    with pytest.raises(LakefrontError, match="Invalid source name"):
+        ctx.source_attach("my-invalid name!", kind="local", path=src.as_posix())
+
+
+def test_context_source_attach_duplicate_name_raises(tmp_path, ctx):
+    src = tmp_path / "file.csv"
+    src.touch()
+    with pytest.raises(SourceExistsError, match="already exists"):
+        ctx.source_attach(ctx.sources[0].name, kind="local", path=src.as_posix())
 
 
 def test_context_attach_detach_source_cycle(tmp_path, ctx):


### PR DESCRIPTION
Closes #22

## Summary
- Raises `LakefrontError` for invalid source names (must match `^[A-Za-z_][A-Za-z0-9_]*$`) and non-existent paths, instead of silently ignoring or crashing
- Raises `SourceExistsError` (instead of plain `ValueError`) for duplicate names
- TUI catches `LakefrontError` and surfaces the message via `notify` with an 8s timeout

## Test plan
- [x] `test_context_source_attach_nonexistent_path_raises` — bad path raises `LakefrontError`
- [x] `test_context_source_attach_invalid_name_raises` — bad identifier raises `LakefrontError`
- [x] `test_context_source_attach_duplicate_name_raises` — duplicate name raises `SourceExistsError`
- [x] Manual TUI smoke test: attach with invalid name / missing path shows error notification, attach with valid inputs succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)